### PR TITLE
#7 api academy registration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   birth_date DateTime
   user_name String
   password String
+  phone_number String
   role Role @default(STUDENT)
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,26 @@ model User {
   role Role @default(STUDENT)
 }
 
+model Academy {
+  id           Int     @id @default(autoincrement())
+  user_id      Int
+  academy_id   String  @unique
+  academy_key  String  @unique
+  academy_name String
+  academy_email String @unique
+  address      String
+  phone_number String
+  status       Status  @default(INITIAL)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+enum Status {
+  INITIAL
+  ACTIVE
+  INACTIVE
+}
+
 enum Role{
   CHIEF
   TEACHER

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,7 +21,7 @@ model User {
 
 model Academy {
   id           Int     @id @default(autoincrement())
-  user_id      Int
+  user_id      String @unique
   academy_id   String  @unique
   academy_key  String  @unique
   academy_name String
@@ -29,8 +29,6 @@ model Academy {
   address      String
   phone_number String
   status       Status  @default(INITIAL)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
 }
 
 enum Status {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,13 @@ model Academy {
   status       Status  @default(INITIAL)
 }
 
+model AcademyUserRegistrationList {
+  academy_id   String  @unique
+  user_id      String @unique
+  role Role @default(STUDENT)
+  status       Status  @default(INITIAL)
+}
+
 enum Status {
   INITIAL
   ACTIVE

--- a/src/app.js
+++ b/src/app.js
@@ -18,8 +18,10 @@ if (process.env.NODE_ENV === "prod") {
 // routes
 const indexRouter = require("./routes/index");
 const userRouter = require("./routes/userRouter");
+const registerationRouter = require("./routes/registerationRouter");
 app.use("/", indexRouter);
 app.use("/user", userRouter);
+app.use("/registeration", registerationRouter);
 
 // error handler
 const errorHandler = require("./lib/middlewares/errorHandler");

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -4,17 +4,23 @@ const { CustomError } = require("../lib/errors/customError");
 const ErrorCode = require("../lib/errors/errorCode");
 const { StatusCodes } = require("http-status-codes");
 const { Status } = require("@prisma/client");
+const crypto = require("crypto");
+
+function generateInviteKey() {
+  return crypto.randomBytes(16).toString("hex");
+}
 
 exports.registAcademy = asyncWrapper(async(req, res, next) => {
     const { user_id, academy_id, academy_key, academy_name, academy_email, address, phone_number, status } =
     req.body;
 
+    const inviteKey = generateInviteKey();
     try {
         const newAcademy = await prisma.academy.create({
             data: {
                 user_id,
                 academy_id,
-                academy_key,
+                academy_key : inviteKey,
                 academy_name,
                 academy_email,
                 address,

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -45,3 +45,52 @@ exports.registAcademy = asyncWrapper(async(req, res, next) => {
         }
     }
 })
+
+exports.registUser = asyncWrapper(async(req, res, next) =>{
+    const { user_id, academy_key, role } = req.body;
+
+    try {
+        //입력받은 academy_key로 academy찾기
+        const searchAcademy = await prisma.academy.findUnique({
+            where : { academy_key }
+        })
+        if(!searchAcademy){
+            return res.status(StatusCodes.NOT_FOUND).json({
+                message: '학원을 찾을 수 없습니다.'
+            });
+        }
+
+        //학원 유저 신청 목록DB에 user_id가 이미 있는지 검사
+        const checkUser = await prisma.AcademyUserRegistrationList.findUnique({
+            where : { user_id }
+        })
+        if (checkUser) {
+            return res.status(StatusCodes.CONFLICT).json({
+                message: '이미 등록요청된 유저입니다.'
+            });
+        }
+        //없다면 DB에 req.body내용 추가
+        const newUser = await prisma.AcademyUserRegistrationList.create({
+            data: {
+                user_id,
+                academy_id : searchAcademy.academy_id,
+                role,
+                status: 'INITIAL'
+            }
+        });
+
+        res.status(StatusCodes.CREATED).json({
+            message: '등록요청이 성공적으로 완료되었습니다.',
+            data: newUser
+        })
+    
+    } catch(error) {
+        if (error.code === 'P2002') { // Prisma의 unique constraint 오류 코드
+            res.status(StatusCodes.DUPLICATE_ENTRY).json({
+                message: '이미 등록요청된 유저입니다.'
+            })
+        }
+    }
+
+
+})

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -3,6 +3,7 @@ const prisma = require("../lib/prisma/index");
 const { CustomError } = require("../lib/errors/customError");
 const ErrorCode = require("../lib/errors/errorCode");
 const { StatusCodes } = require("http-status-codes");
+const { Status } = require("@prisma/client");
 
 exports.registAcademy = asyncWrapper(async(req, res, next) => {
     const { user_id, academy_id, academy_key, academy_name, academy_email, address, phone_number, status } =
@@ -28,9 +29,13 @@ exports.registAcademy = asyncWrapper(async(req, res, next) => {
         });
     } catch (error) {
         if (error.code === 'P2002') { // Prisma의 unique constraint 오류 코드
-            next(new CustomError(ErrorCode.DUPLICATE_ENTRY, '이미 존재하는 학원 ID나 이메일입니다.'));
+            res.status(StatusCodes.DUPLICATE_ENTRY).json({
+                message: '이미 존재하는 학원 ID나 이메일입니다.'
+            })
         } else {
-            next(new CustomError(ErrorCode.INTERNAL_SERVER_ERROR, '학원 등록 중 오류가 발생했습니다.'));
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                message: '학원 등록 중 오류가 발생했습니다.'
+            })
         }
     }
 })

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -1,0 +1,36 @@
+const { asyncWrapper } = require("../lib/middlewares/async");
+const prisma = require("../lib/prisma/index");
+const { CustomError } = require("../lib/errors/customError");
+const ErrorCode = require("../lib/errors/errorCode");
+const { StatusCodes } = require("http-status-codes");
+
+exports.registAcademy = asyncWrapper(async(req, res, next) => {
+    const { user_id, academy_id, academy_key, academy_name, academy_email, address, phone_number, status } =
+    req.body;
+
+    try {
+        const newAcademy = await prisma.academy.create({
+            data: {
+                user_id,
+                academy_id,
+                academy_key,
+                academy_name,
+                academy_email,
+                address,
+                phone_number,
+                status: 'INITIAL' // 학원의 상태를 'INITIAL'로 설정합니다.
+            }
+        });
+
+        res.status(StatusCodes.CREATED).json({
+            message: '학원 등록이 성공적으로 완료되었습니다.',
+            data: newAcademy
+        });
+    } catch (error) {
+        if (error.code === 'P2002') { // Prisma의 unique constraint 오류 코드
+            next(new CustomError(ErrorCode.DUPLICATE_ENTRY, '이미 존재하는 학원 ID나 이메일입니다.'));
+        } else {
+            next(new CustomError(ErrorCode.INTERNAL_SERVER_ERROR, '학원 등록 중 오류가 발생했습니다.'));
+        }
+    }
+})

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -96,18 +96,10 @@ exports.registerUser = asyncWrapper(async(req, res, next) =>{
         })
     
     } catch(error) {
-        if (error.code === 'P2002') { // Prisma의 unique constraint 오류 코드
-            res.status(StatusCodes.DUPLICATE_ENTRY).json({
-                message: '이미 등록요청된 유저입니다.'
-            })
-        }else {
-            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-                message: '사용자 등록 요청 중 오류가 발생했습니다.'
-            })
-        }
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+            message: '사용자 등록 요청 중 오류가 발생했습니다.'
+        })
     }
-
-
 })
 
 exports.decideUserStatus = asyncWrapper(async(req, res, next) =>{

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -11,7 +11,7 @@ function generateInviteKey() {
   return crypto.randomBytes(16).toString("hex");
 }
 
-exports.registAcademy = asyncWrapper(async(req, res, next) => {
+exports.registerAcademy = asyncWrapper(async(req, res, next) => {
     const { user_id, academy_id, academy_key, academy_name, academy_email, address, phone_number, status } =
     req.body;
 
@@ -47,7 +47,7 @@ exports.registAcademy = asyncWrapper(async(req, res, next) => {
     }
 })
 
-exports.registUser = asyncWrapper(async(req, res, next) =>{
+exports.registerUser = asyncWrapper(async(req, res, next) =>{
     const { user_id, academy_key, role } = req.body;
 
     try {

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -33,7 +33,7 @@ exports.createUser = asyncWrapper(async (req, res, next) => {
         user_id,
         academy_id,
         email,
-        birth_date,
+        birth_date: new Date(req.body.birth_date),
         user_name,
         password: hashedPassword,
         role,

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const regsiterController = require('../controllers/registerationController');
+
+router.post('/request', regsiterController.registAcademy);
+
+module.exports = router;

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -7,6 +7,8 @@ router.post('/request/academy', authenticateJWT, regsiterController.registAcadem
 
 router.post('/request/user',authenticateJWT, regsiterController.registUser);
 
+router.post('/decide/user', authenticateJWT, regsiterController.decideUserStatus);
+
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {
 //   res.json({ message: "This is a protected route", user: req.user });

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -1,13 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const regsiterController = require('../controllers/registerationController');
+const registerController = require('../controllers/registerationController');
 const { authenticateJWT } = require('../lib/middlewares/auth.js')
 
-router.post('/request/academy', authenticateJWT, regsiterController.registAcademy);
+router.post('/request/academy', authenticateJWT, registerController.registerAcademy);
 
-router.post('/request/user',authenticateJWT, regsiterController.registUser);
+router.post('/request/user',authenticateJWT, registerController.registerUser);
 
-router.post('/decide/user', authenticateJWT, regsiterController.decideUserStatus);
+router.post('/decide/user', authenticateJWT, registerController.decideUserStatus);
 
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -5,6 +5,8 @@ const { authenticateJWT } = require('../lib/middlewares/auth.js')
 
 router.post('/request/academy', authenticateJWT, regsiterController.registAcademy);
 
+router.post('/request/user',authenticateJWT, regsiterController.registUser);
+
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {
 //   res.json({ message: "This is a protected route", user: req.user });

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -1,7 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const regsiterController = require('../controllers/registerationController');
+const { authenticateJWT } = require('../lib/middlewares/auth.js')
 
-router.post('/request', regsiterController.registAcademy);
+router.post('/request/academy', authenticateJWT, regsiterController.registAcademy);
+
+// 보호된 라우트 예시
+// router.get("/protected", authenticateJWT, (req, res) => {
+//   res.json({ message: "This is a protected route", user: req.user });
+// });
 
 module.exports = router;


### PR DESCRIPTION
## #️⃣연관된 이슈

#7 

## 📝작업 내용

1. 원장이 학원을 우리 서비스에 등록요청 -> DB 학원테이블에 학원추가(승인대기) + academy_key 생성시키기 구현||테스트 완료.
2.강사/학생이 academy_key를 이용하여 학원에 등록 구현||테스트 완료.
3.원장이 강사/학생의 등록요청을 승인/거절 구현||테스트 완료.

## 💬리뷰 요구사항(선택)
