### PR TITLE
#13 api return request list

### DIFF
--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -154,7 +154,7 @@ exports.listUser = asyncWrapper(async (req, res, next) => {
         if (req_role === "TEACHER") {
             result = await prisma.AcademyUserRegistrationList.findMany({
                 where: {
-                    academy_id: academy_id,
+                    academy_id : academy_id,
                     role: "TEACHER",
                     status: "INITIAL"
                 }
@@ -162,25 +162,25 @@ exports.listUser = asyncWrapper(async (req, res, next) => {
         } else if (req_role === "STUDENT") {
             result = await prisma.AcademyUserRegistrationList.findMany({
                 where: {
-                    academy_id: academy_id,
+                    academy_id : academy_id,
                     role: "STUDENT",
                     status: "INITIAL"
                 }
             });
         } else {
-            throw new CustomError(
+            return next(new CustomError(
                 "유효하지 않은 역할입니다.",
                 StatusCodes.BAD_REQUEST,
                 StatusCodes.BAD_REQUEST
-            );
+            ));
         }
 
         if (!result || result.length === 0) {
-            throw new CustomError(
+            return next(new CustomError(
                 "해당 조건에 맞는 사용자가 없습니다.",
                 StatusCodes.NOT_FOUND,
                 StatusCodes.NOT_FOUND
-            );
+            ));
         }
 
         res.status(StatusCodes.OK).json({ data: result });
@@ -188,6 +188,33 @@ exports.listUser = asyncWrapper(async (req, res, next) => {
     } catch (error) {
         next(new CustomError(
             "불러오는 중에 오류가 발생했습니다.",
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            StatusCodes.INTERNAL_SERVER_ERROR
+        ));
+    }
+})
+
+exports.listAcademy = asyncWrapper(async(req, res, next) => {
+    try {
+        const result = await prisma.Academy.findMany({
+            where : {
+                status: "INITIAL"
+            }
+        })
+
+        if (!result || result.length === 0) {
+            return next(new CustomError(
+                "해당 조건에 맞는 사용자가 없습니다.",
+                StatusCodes.NOT_FOUND,
+                StatusCodes.NOT_FOUND
+            ));
+        }
+
+        res.status(StatusCodes.OK).json({ data: result });
+
+    } catch(error) {
+        next(new CustomError(
+            "아카데미 목록을 불러오는 중에 오류가 발생했습니다.",
             StatusCodes.INTERNAL_SERVER_ERROR,
             StatusCodes.INTERNAL_SERVER_ERROR
         ));

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -144,3 +144,52 @@ exports.decideUserStatus = asyncWrapper(async(req, res, next) =>{
         data: updatedUser
     })
 })
+
+exports.listUser = asyncWrapper(async (req, res, next) => {
+    const { req_role, academy_id } = req.body;
+
+    try {
+        let result;
+
+        if (req_role === "TEACHER") {
+            result = await prisma.AcademyUserRegistrationList.findMany({
+                where: {
+                    academy_id: academy_id,
+                    role: "TEACHER",
+                    status: "INITIAL"
+                }
+            });
+        } else if (req_role === "STUDENT") {
+            result = await prisma.AcademyUserRegistrationList.findMany({
+                where: {
+                    academy_id: academy_id,
+                    role: "STUDENT",
+                    status: "INITIAL"
+                }
+            });
+        } else {
+            throw new CustomError(
+                "유효하지 않은 역할입니다.",
+                StatusCodes.BAD_REQUEST,
+                StatusCodes.BAD_REQUEST
+            );
+        }
+
+        if (!result || result.length === 0) {
+            throw new CustomError(
+                "해당 조건에 맞는 사용자가 없습니다.",
+                StatusCodes.NOT_FOUND,
+                StatusCodes.NOT_FOUND
+            );
+        }
+
+        res.status(StatusCodes.OK).json({ data: result });
+
+    } catch (error) {
+        next(new CustomError(
+            "불러오는 중에 오류가 발생했습니다.",
+            StatusCodes.INTERNAL_SERVER_ERROR,
+            StatusCodes.INTERNAL_SERVER_ERROR
+        ));
+    }
+})

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -9,6 +9,8 @@ router.post('/request/user',authenticateJWT, registerController.registerUser);
 
 router.post('/decide/user', authenticateJWT, registerController.decideUserStatus);
 
+router.get('/list/user', authenticateJWT, registerController.listUser);
+
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {
 //   res.json({ message: "This is a protected route", user: req.user });

--- a/src/routes/registerationRouter.js
+++ b/src/routes/registerationRouter.js
@@ -11,6 +11,8 @@ router.post('/decide/user', authenticateJWT, registerController.decideUserStatus
 
 router.get('/list/user', authenticateJWT, registerController.listUser);
 
+router.get('/list/academy', authenticateJWT, registerController.listAcademy);
+
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {
 //   res.json({ message: "This is a protected route", user: req.user });


### PR DESCRIPTION
## #️⃣연관된 이슈

#13 

## 📝작업 내용

 1. 학원 유저 신청 목록 테이블에서 academy_id로 특정학원의 강사/학생의 등록요청을 반환함.
 2. Academy테이블에서 status가 INITIAIL(승인대기) 상태인 학원들만 반환

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

에러 처리할 때 throw 말고 next로 넘겨줘야 에러 처리가 잘 되더라고요. 다른 부분도 throw 대신 next로 넘겨줘야 할 것 같습니다.
