### PR TITLE
#46 fix: /:lecture_id 뒤 숫자입력은 시험 유형 삭제 API호출 되도록 변경

### DIFF
--- a/src/routes/lectureRouter.js
+++ b/src/routes/lectureRouter.js
@@ -31,7 +31,7 @@ router.get(
 
 // 시험 유형 삭제
 router.delete(
-  "/:lecture_id/:exam_type_id",
+  "/:lecture_id/:exam_type_id(\\d+)",
   authenticateJWT,
   lectureController.deleteExamType
 );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

> url 파라미터 중첩 오류 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
