### PR TITLE
Feat/#54 family model 추가 및 API 구현 완료

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,12 +21,14 @@ model User {
   image        String   @default("default.png")
 
   // Relations
-  academy          Academy?                     @relation(fields: [academy_id], references: [academy_id], name: "UserAcademyRelation")
-  chief            Chief_Academy?               @relation("UserChiefRelation")
-  registrationList AcademyUserRegistrationList? @relation("AcademyUserRegistrationList_User_Relation")
-  lectures         Lecture[]                    @relation("Teacher_Lecture") //강사-강의 1:N
-  registerdLecture LectureParticipant[] //강의-수강생 N:M
-  exam_scores      ExamUserScore[]              @relation("ExamUserScore_User_Relation") // User : ExamUserScore  (M:N relationship with Exam)
+  academy           Academy?                     @relation(fields: [academy_id], references: [academy_id], name: "UserAcademyRelation")
+  chief             Chief_Academy?               @relation("UserChiefRelation")
+  registrationList  AcademyUserRegistrationList? @relation("AcademyUserRegistrationList_User_Relation")
+  lectures          Lecture[]                    @relation("Teacher_Lecture") //강사-강의 1:N
+  registerdLecture  LectureParticipant[] //강의-수강생 N:M
+  exam_scores       ExamUserScore[]              @relation("ExamUserScore_User_Relation") // User : ExamUserScore  (M:N relationship with Exam)
+  familiesAsStudent Family[]                     @relation("StudentFamilyRelation") // Family 테이블에서 student_id로 연결
+  familiesAsParent  Family[]                     @relation("ParentFamilyRelation") // Family 테이블에서 parent_id로 연결
 }
 
 model Academy {
@@ -162,6 +164,17 @@ model ExamUserScore {
   user User @relation("ExamUserScore_User_Relation", fields: [user_id], references: [user_id], onDelete: Cascade)
 
   @@id([exam_id, user_id]) // Composite Primary Key for the many-to-many relationship
+}
+
+model Family {
+  student_id String
+  parent_id  String
+
+  // Relations
+  student User @relation("StudentFamilyRelation", fields: [student_id], references: [user_id], onDelete: Cascade)
+  parent  User @relation("ParentFamilyRelation", fields: [parent_id], references: [user_id], onDelete: Cascade)
+
+  @@id([student_id, parent_id]) // 복합 기본 키 설정 (학생과 부모의 관계가 유일하도록)
 }
 
 enum Status {

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -103,13 +103,46 @@ exports.registerUser = asyncWrapper(async(req, res, next) =>{
                 status: "PENDING"
             }
         });
+        
+        // 학생의 경우 부모도 등록. response할 때 부모의 user_id도 같이 보내줌.
+        let parent = null;
+        if (newUser.role === "STUDENT") {
+            parent = await prisma.Family.findFirst({
+              where: { student_id: user_id },
+            });
+            console.log(`parent : `);
+            console.log(parent);
+            if (parent) {
 
+                // 부모가 등록되지 않은 경우에만 추가
+                await prisma.AcademyUserRegistrationList.create({
+                    data: {
+                    user_id: parent.parent_id,
+                    academy_id: searchAcademy.academy_id,
+                    role: "PARENT",
+                    status: "PENDING",
+                    },
+                });
+            } 
+          }
+        
+        const resData = {
+            user_id: newUser.user_id,
+            academy_id: newUser.academy_id,
+            role: newUser.role,
+            status: newUser.status,
+            parent_id: (newUser.role === "STUDENT" && parent) ? parent.parent_id : null,
+        };
+        
         res.status(StatusCodes.CREATED).json({
             message: '등록요청이 성공적으로 완료되었습니다.',
-            data: newUser
-        })
-    
+            data: resData
+        });
+        
+        
     } catch(error) {
+        console.error("Error during registration: ", error.message); // 에러 메시지 출력
+
         throw new CustomError(
             "사용자 등록 요청 중 오류가 발생했습니다.",
             StatusCodes.INTERNAL_SERVER_ERROR,

--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -73,11 +73,20 @@ exports.registerUser = asyncWrapper(async(req, res, next) =>{
                 );
               }
         })
-
+        
+        // 유효성 검사 -> User DB에 user_id가 존재하는지 검사
+        if(await prisma.user.findUnique({where : {user_id:user_id, role:role}}) === null) {
+            return next(new CustomError(
+                "해당하는 유저가 존재하지 않습니다. 또는 역할이 잘못되었습니다.",
+                StatusCodes.NOT_FOUND,
+                StatusCodes.NOT_FOUND
+            ));
+        }
         //학원 유저 신청 목록DB에 user_id가 이미 있는지 검사
         const checkUser = await prisma.AcademyUserRegistrationList.findUnique({
-            where : { user_id }
+            where : { user_id: user_id, role: role}
         })
+
         if (checkUser) {
             throw new CustomError(
                 "이미 등록요청된 유저입니다.",

--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -72,9 +72,34 @@ exports.deleteStudent = asyncWrapper(async (req, res, next) => {
     },
   });
 
+  const family = await prisma.family.findFirst({
+    where: {
+      student_id: user_id,
+    },
+  });
+  const parent_id = family ? family.parent_id : null;
+  
+  if (parent_id) {
+    //학생의 academy_id를 NULL로 업데이트
+    await prisma.user.update({
+      where: {
+        user_id: parent_id,
+      },
+      data: {
+        academy_id: null,
+      },
+    });
+    //AcademyUserRegistrationList에서 해당 부모 행 삭제
+    await prisma.AcademyUserRegistrationList.delete({
+      where: {
+        user_id: parent_id,
+      },
+    });
+  }
+
   // 성공 응답
-  res.status(StatusCodes.OK).json({
-    message: `학생 ID ${user_id}의 academy_id가 성공적으로 NULL로 설정되었고, 등록 목록에서 삭제되었습니다.`,
+  return res.status(StatusCodes.OK).json({
+    message: `학생 ID ${user_id}, 학부모 ID ${parent_id} 의 academy_id가 성공적으로 NULL로 설정되었고, 등록 목록에서 삭제되었습니다.`,
   });
 });
 

--- a/src/controllers/studentController.js
+++ b/src/controllers/studentController.js
@@ -80,7 +80,7 @@ exports.deleteStudent = asyncWrapper(async (req, res, next) => {
   const parent_id = family ? family.parent_id : null;
   
   if (parent_id) {
-    //학생의 academy_id를 NULL로 업데이트
+    //부모의 academy_id를 NULL로 업데이트
     await prisma.user.update({
       where: {
         user_id: parent_id,

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -11,7 +11,11 @@ router.post(`/signup`, userController.createUser);
 router.post("/login", userController.createJWT);
 
 // 로그아웃
-router.post("/logout", authenticateJWT("ADMIN", "CHIEF", "TEACHER", "STUDENT", "PARENT"), userController.removeJWT);
+router.post(
+  "/logout",
+  authenticateJWT("ADMIN", "CHIEF", "TEACHER", "STUDENT", "PARENT"),
+  userController.removeJWT
+);
 
 // 리프레시 토큰을 사용하여 액세스 토큰 갱신
 router.post("/refresh-token", userController.refreshToken);
@@ -26,7 +30,11 @@ router.post("/find-id", userController.findUserId);
 router.post("/reset-password", userController.resetUserPassword);
 
 // 회원 탈퇴
-router.delete("/:user_id", authenticateJWT("ADMIN", "CHIEF", "TEACHER", "STUDENT", "PARENT"), userController.deleteUser);
+router.delete(
+  "/:user_id",
+  authenticateJWT("ADMIN", "CHIEF", "TEACHER", "STUDENT", "PARENT"),
+  userController.deleteUser
+);
 
 // 사용자 이미지 정보 API
 router.get(
@@ -56,6 +64,9 @@ router.put(
   uploadImage.single("file"),
   userController.updateUserImageInfo
 );
+
+// 학생 학부모 관계설정 API
+router.post("/family", userController.setFamily);
 
 // 보호된 라우트 예시
 // router.get("/protected", authenticateJWT, (req, res) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#54 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
가족관계 설정 API를 만들었습니다.
1. Family modle 생성
2. 유저 정보 조회시 가족관계 반환
3. 학생이 학원 등록 요청할 시 부모도 자동 등록
4. 학생이 승인될 때, 학부모도User DB에 존재한다면 같이 승인
5. 이미 학생이 등록된 상태라면, 학생의 상태(대기, 승인, 거절)에 따라 학부모 관게 설정시 등록
6. 학부모의 학원 탈퇴 - 학생 탈퇴시 같이 하기.
7. 
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
