### PR TITLE
#68 add: 전체강사조회API 응답에 담당과목,폰번호,이메일 추가

### DIFF
--- a/src/controllers/teacherController.js
+++ b/src/controllers/teacherController.js
@@ -84,6 +84,20 @@ exports.getTeacher = asyncWrapper(async(req, res, next) => {
                 academy_id : academy_id,
                 role : "TEACHER",
                 status : "APPROVED"
+            },
+            include : {
+                user : {
+                    select : {
+                        email : true,
+                        phone_number : true,
+                        lectures : {
+                            select : {
+                                lecture_id : true,
+                                lecture_name : true
+                            }
+                        }
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #68 

## 📝작업 내용

> 전체강사 조회 API 응답에 강사의 담당과목, 폰번호, 이메일을 추가하였습니다.

AcademyUserRegistrationList테이블과 User테이블을 조인하여 폰번호, 이메일을 추가하였고,

User테이블과 Lecture테이블을 조인하여 담당과목을 추가하였습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/fa7c74b6-232f-4212-930e-e65f65ab279f)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
