### PR TITLE
#71 fix: 유저의 학원 등록 승인 시, User DB academy_id에 반영

### DIFF
--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -181,6 +181,17 @@ exports.decideUserStatus = asyncWrapper(async (req, res, next) => {
         data: { status: newStatus },
     });
 
+    if(newStatus === 'APPROVED') {
+        await prisma.user.update({
+            where: {
+                user_id: user_id,
+            },
+            data: {
+                academy_id: academy_id,
+            },
+        });
+    }
+
     let parent = null;
     if (searchUser.role === "STUDENT") {
         parent = await prisma.Family.findFirst({ where: { student_id: user_id } });
@@ -193,6 +204,17 @@ exports.decideUserStatus = asyncWrapper(async (req, res, next) => {
                 },
                 data: { status: newStatus },
             });
+
+            if(newStatus === 'APPROVED') {
+                await prisma.user.update({
+                    where: {
+                        user_id: parent.parent_id,
+                    },
+                    data: {
+                        academy_id: academy_id,
+                    },
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#71
## 📝작업 내용
- 유저 승인 하면, User DB에도 academy_id 반영됩니다.
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
- 응답
![image](https://github.com/user-attachments/assets/19449d6f-5fa3-4c54-abf5-55ceb744e722)

- 유저 테이블 (parent의 academy_id가 반영이 됨)
![image](https://github.com/user-attachments/assets/21952e3d-42b2-4646-a7d8-8f26ea5b7fc1)

- 유저 등록 테이블
![image](https://github.com/user-attachments/assets/942cba43-ee92-4a82-87ed-459b5f4866c3)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
