### PR TITLE
#79 fix:  유저 이미지 조회 시 에러 & 원장등록 요청 에러 코드 수정

### DIFF
--- a/src/controllers/registerationController.js
+++ b/src/controllers/registerationController.js
@@ -39,8 +39,8 @@ exports.registerAcademy = asyncWrapper(async(req, res, next) => {
         if (error.code === 'P2002') { // Prisma의 unique constraint 오류 코드
             return next(new CustomError(
                 "이미 존재하는 학원 ID나 이메일입니다.",
-                StatusCodes.DUPLICATE_ENTRY,
-                StatusCodes.DUPLICATE_ENTRY
+                StatusCodes.CONFLICT,
+                StatusCodes.CONFLICT
             ));
         } else {
             return next(new CustomError(

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -12,6 +12,7 @@ const {
 } = require("../lib/jwt/index.js");
 const jwt = require("jsonwebtoken");
 const path = require("path");
+const fs = require("fs");
 const multer = require("multer");
 const { secretKey, gmailID, gmailPW } = require("../config/secret.js");
 const { stat } = require("fs");
@@ -375,8 +376,13 @@ exports.getUserBasicInfo = asyncWrapper(async (req, res, next) => {
 
 exports.getUserImageInfo = asyncWrapper(async (req, res, next) => {
   const user_id = req.params["user_id"];
-
   const user = await findUserByCriteria({ user_id });
+
+  if (!user || !user.image) {
+    return next(
+      new CustomError("해당 사용자를 찾을 수 없습니다.", StatusCodes.NOT_FOUND)
+    );
+  }
 
   // 이미지 파일 경로 설정
   const imagePath = path.resolve(
@@ -384,8 +390,14 @@ exports.getUserImageInfo = asyncWrapper(async (req, res, next) => {
     `../../public/profile/${user.image}`
   );
 
+  if (!fs.existsSync(imagePath)) {
+    return next(
+      new CustomError("이미지 파일을 찾을 수 없습니다.", StatusCodes.NOT_FOUND)
+    );
+  }
+
   // 이미지 파일 반환
-  res.sendFile(imagePath);
+  return res.sendFile(imagePath);
 });
 
 // 회원 기본 정보 수정

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -380,7 +380,11 @@ exports.getUserImageInfo = asyncWrapper(async (req, res, next) => {
 
   if (!user || !user.image) {
     return next(
-      new CustomError("해당 사용자를 찾을 수 없습니다.", StatusCodes.NOT_FOUND)
+      new CustomError(
+        "해당 사용자를 찾을 수 없습니다.",
+        StatusCodes.NOT_FOUND,
+        StatusCodes.NOT_FOUND
+      )
     );
   }
 
@@ -392,7 +396,11 @@ exports.getUserImageInfo = asyncWrapper(async (req, res, next) => {
 
   if (!fs.existsSync(imagePath)) {
     return next(
-      new CustomError("이미지 파일을 찾을 수 없습니다.", StatusCodes.NOT_FOUND)
+      new CustomError(
+        "이미지 파일을 찾을 수 없습니다.",
+        StatusCodes.NOT_FOUND,
+        StatusCodes.NOT_FOUND
+      )
     );
   }
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -49,31 +49,35 @@ exports.createUser = asyncWrapper(async (req, res, next) => {
     })
     .catch((err) => {
       // Prisma의 고유성 제약 조건 에러 처리 (이메일 또는 아이디 중복)
-      if (err.code === 'P2002') {
+      if (err.code === "P2002") {
         const duplicatedField = err.meta.target[0]; // 중복된 필드를 확인
         let errorMessage = "중복된 값이 있습니다.";
 
-        if (duplicatedField === 'email') {
+        if (duplicatedField === "email") {
           errorMessage = "이미 사용 중인 이메일입니다.";
-        } else if (duplicatedField === 'user_id') {
+        } else if (duplicatedField === "user_id") {
           errorMessage = "이미 존재하는 아이디입니다.";
-        } else if (duplicatedField === 'phone_number') {
+        } else if (duplicatedField === "phone_number") {
           errorMessage = "이미 존재하는 휴대폰 번호 입니다.";
         }
 
-        return next(new CustomError(
-          errorMessage,
-          StatusCodes.CONFLICT,
-          StatusCodes.CONFLICT
-        ));
+        return next(
+          new CustomError(
+            errorMessage,
+            StatusCodes.CONFLICT,
+            StatusCodes.CONFLICT
+          )
+        );
       }
 
       // 그 외의 에러 처리
-      return next(new CustomError(
-        "회원가입 중 오류가 발생했습니다.",
-        StatusCodes.INTERNAL_SERVER_ERROR,
-        StatusCodes.INTERNAL_SERVER_ERROR
-      ));
+      return next(
+        new CustomError(
+          "회원가입 중 오류가 발생했습니다.",
+          StatusCodes.INTERNAL_SERVER_ERROR,
+          StatusCodes.INTERNAL_SERVER_ERROR
+        )
+      );
     });
 });
 
@@ -128,7 +132,7 @@ exports.createJWT = asyncWrapper(async (req, res) => {
       image: user.image,
     };
 
-    res.status(StatusCodes.CREATED).json({
+    return res.status(StatusCodes.CREATED).json({
       message: "로그인 되었습니다.",
       userStatus,
       accessToken: accessToken,
@@ -148,50 +152,58 @@ exports.removeJWT = asyncWrapper(async (req, res, next) => {
   const refreshToken = req.cookies.refreshToken;
   // 검사1: 토큰이 없을 경우
   if (!refreshToken) {
-    return next(new CustomError(
-      "리프레시 토큰이 쿠키에 존재하지 않습니다.",
-      StatusCodes.BAD_REQUEST,
-      StatusCodes.BAD_REQUEST
-    ));
+    return next(
+      new CustomError(
+        "리프레시 토큰이 쿠키에 존재하지 않습니다.",
+        StatusCodes.BAD_REQUEST,
+        StatusCodes.BAD_REQUEST
+      )
+    );
   }
   // 검사 2: 토큰이 정상적인 토큰이 아닌 경우
   try {
     jwt.verify(refreshToken, secretKey); // 토큰 유효성 검증
   } catch (err) {
-    return next(new CustomError(
-      "잘못된 리프레시 토큰입니다.",
-      StatusCodes.BAD_REQUEST,
-      StatusCodes.BAD_REQUEST
-    ));
+    return next(
+      new CustomError(
+        "잘못된 리프레시 토큰입니다.",
+        StatusCodes.BAD_REQUEST,
+        StatusCodes.BAD_REQUEST
+      )
+    );
   }
 
   // 쿠키 삭제
   res.clearCookie("refreshToken");
-  res.status(StatusCodes.OK).json({ message: "로그아웃 되었습니다." });
+  return res.status(StatusCodes.OK).json({ message: "로그아웃 되었습니다." });
 });
 
 // 리프레시 토큰을 사용하여 액세스 토큰 갱신
 exports.refreshToken = asyncWrapper(async (req, res) => {
   const refreshToken = req.cookies.refreshToken;
-  
+
   if (!refreshToken) {
-    return next(new CustomError(
-      "리프레시 토큰이 쿠키에 존재하지 않습니다.",
-      StatusCodes.BAD_REQUEST,
-      StatusCodes.BAD_REQUEST
-    ));
+    return next(
+      new CustomError(
+        "리프레시 토큰이 쿠키에 존재하지 않습니다.",
+        StatusCodes.BAD_REQUEST,
+        StatusCodes.BAD_REQUEST
+      )
+    );
   }
   const newAccessToken = refreshAccessToken(refreshToken);
 
   if (!newAccessToken) {
-    return next(new CustomError(
-      "유효하지 않거나 만료된 리프레시 토큰입니다. 다시 로그인 해주세요.",
-      StatusCodes.FORBIDDEN,
-      StatusCodes.FORBIDDEN
-    ));
+    return next(
+      new CustomError(
+        "유효하지 않거나 만료된 리프레시 토큰입니다. 다시 로그인 해주세요.",
+        StatusCodes.FORBIDDEN,
+        StatusCodes.FORBIDDEN
+      )
+    );
   }
 
-  res.status(StatusCodes.CREATED).json({
+  return res.status(StatusCodes.CREATED).json({
     message: "액세스 토큰이 갱신되었습니다.",
     accessToken: newAccessToken,
   });
@@ -202,11 +214,13 @@ exports.checkIdDuplicated = asyncWrapper(async (req, res, next) => {
 
   // user_id가 공백인 경우
   if (user_id === null || !user_id.trim()) {
-    return next(new CustomError(
-      "아이디를 입력해 주세요.",
-      StatusCodes.BAD_REQUEST,
-      StatusCodes.BAD_REQUEST
-    ));
+    return next(
+      new CustomError(
+        "아이디를 입력해 주세요.",
+        StatusCodes.BAD_REQUEST,
+        StatusCodes.BAD_REQUEST
+      )
+    );
   }
 
   const user = await prisma.user
@@ -215,19 +229,23 @@ exports.checkIdDuplicated = asyncWrapper(async (req, res, next) => {
     })
     .catch((err) => {
       // Prisma 에러가 발생하면 CustomError로 처리하여 미들웨어 체인에 전달
-      return next(new CustomError(
-        "Prisma Error occurred!",
-        ErrorCode.INTERNAL_SERVER_PRISMA_ERROR,
-        StatusCodes.INTERNAL_SERVER_ERROR
-      ));
+      return next(
+        new CustomError(
+          "Prisma Error occurred!",
+          ErrorCode.INTERNAL_SERVER_PRISMA_ERROR,
+          StatusCodes.INTERNAL_SERVER_ERROR
+        )
+      );
     });
 
   if (user) {
-    return next(new CustomError(
-      "이미 존재하는 아이디입니다.",
-      StatusCodes.CONFLICT,
-      StatusCodes.CONFLICT
-    ));
+    return next(
+      new CustomError(
+        "이미 존재하는 아이디입니다.",
+        StatusCodes.CONFLICT,
+        StatusCodes.CONFLICT
+      )
+    );
   } else {
     return res
       .status(StatusCodes.OK)
@@ -243,7 +261,7 @@ exports.findUserId = asyncWrapper(async (req, res, next) => {
 
   const user = await findUserByCriteria({ email, phone_number });
 
-  res.status(StatusCodes.OK).json({ user_id: user.user_id });
+  return res.status(StatusCodes.OK).json({ user_id: user.user_id });
 });
 
 // 비밀번호 재설정
@@ -308,7 +326,9 @@ exports.deleteUser = asyncWrapper(async (req, res, next) => {
     where: { user_id },
   });
 
-  res.status(StatusCodes.OK).json({ message: "회원 탈퇴가 완료되었습니다." });
+  return res
+    .status(StatusCodes.OK)
+    .json({ message: "회원 탈퇴가 완료되었습니다." });
 });
 
 // userController.js
@@ -347,7 +367,7 @@ exports.getUserBasicInfo = asyncWrapper(async (req, res, next) => {
         : null, // family가 없으면 null을 반환
   };
 
-  res.status(StatusCodes.OK).json({
+  return res.status(StatusCodes.OK).json({
     message: "회원 정보 조회가 완료되었습니다.",
     data: user_data,
   });
@@ -401,7 +421,7 @@ exports.updateUserBasicInfo = asyncWrapper(async (req, res, next) => {
     },
   });
 
-  res.status(StatusCodes.OK).json({
+  return res.status(StatusCodes.OK).json({
     message: "회원 정보가 수정되었습니다.",
     user_id: user_id,
     email: email,
@@ -435,7 +455,7 @@ exports.updateUserImageInfo = asyncWrapper(async (req, res, next) => {
     },
   });
 
-  res.status(StatusCodes.OK).json({
+  return res.status(StatusCodes.OK).json({
     message: "회원 이미지 정보가 수정되었습니다.",
     user_id: user_id,
     image: imagePath,

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -75,7 +75,6 @@ const uploadImage = require("../lib/middlewares/uploadImage");
 // 회원가입
 router.post(`/signup`, userController.createUser);
 
-
 /**
  * @swagger
  * /user/login:
@@ -165,7 +164,6 @@ router.post(`/signup`, userController.createUser);
 // 로그인
 router.post("/login", userController.createJWT);
 
-
 /**
  * @swagger
  * /user/logout:
@@ -201,7 +199,6 @@ router.post(
   authenticateJWT("ADMIN", "CHIEF", "TEACHER", "STUDENT", "PARENT"),
   userController.removeJWT
 );
-
 
 /**
  * @swagger
@@ -308,7 +305,6 @@ router.post("/refresh-token", userController.refreshToken);
 // 아이디 중복 확인
 router.get("/check-id/:user_id", userController.checkIdDuplicated);
 
-
 /**
  * @swagger
  * /user/find-id:
@@ -399,7 +395,6 @@ router.post("/find-id", userController.findUserId);
 // 비밀번호 찾기
 router.post("/reset-password", userController.resetUserPassword);
 
-
 /**
  * @swagger
  * /user/{user_id}:
@@ -437,7 +432,6 @@ router.delete(
   userController.deleteUser
 );
 
-
 /**
  * @swagger
  * /user/{user_id}/image-info:
@@ -460,11 +454,32 @@ router.delete(
  *             schema:
  *               type: string
  *               format: binary
+ *           image/png:
+ *             schema:
+ *               type: string
+ *               format: binary
  *       404:
- *         description: 해당 사용자를 찾을 수 없습니다.
+ *         description: 해당 사용자를 찾을 수 없거나 이미지 파일이 없습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 해당 사용자를 찾을 수 없습니다.
  *       500:
  *         description: 서버에서 이미지를 반환하는 중 오류가 발생했습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 서버에서 이미지를 반환하는 중 오류가 발생했습니다.
  */
+
 // 사용자 이미지 정보 API
 router.get(
   "/:user_id/image-info",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#79 
## 📝작업 내용
1. 유저 이미지 조회 시 에러
- 유저 이미지 조회 API에서 [ERR_HTTP_HEADERS_SENT] 가 났습니다.
- 따라서 유저가 없는경우, 이미지가 서버 파일 시스템어 없는경우 유효성 검사를 추가했습니다.
- 그리고 User API의 모든 res.status에 return을 추가해줬습니다.

2. 원장등록 요청 에러 코드 수정
- duplicate entry로 되어있는 에러코드를 409 conflict로 수정했습니다.(중복은 409로 통일)
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
