### PR TITLE
#90 add 강사목록조회api에 강사이름 추가

### DIFF
--- a/src/controllers/teacherController.js
+++ b/src/controllers/teacherController.js
@@ -88,6 +88,8 @@ exports.getTeacher = asyncWrapper(async(req, res, next) => {
             include : {
                 user : {
                     select : {
+                        user_id : true,
+                        user_name : true,
                         email : true,
                         phone_number : true,
                         lectures : {
@@ -109,10 +111,24 @@ exports.getTeacher = asyncWrapper(async(req, res, next) => {
             ));
         }
 
+        // academy_id와 user_id를 제외한 필드만 반환
+        const formattedTeachers = getTeacher.map(teacher => {
+            const { academy_id, ...rest } = teacher.user;  // academy_id와 user_id 제외
+            return {
+                ...rest, // 나머지 필드 반환
+                lectures: teacher.user.lectures  // lectures 정보 추가
+            };
+        });
+
         // 성공 응답
         return res.status(StatusCodes.OK).json({ 
             message: "강사를 성공적으로 불러왔습니다.",
-            data: getTeacher
+            data: {
+                academy_id: academy_id,
+                role: "TEACHER",
+                status: "APPROVED",
+                user : formattedTeachers
+            }
         });
     } catch(error) {
         return next(new CustomError(

--- a/src/routes/teacherRouter.js
+++ b/src/routes/teacherRouter.js
@@ -44,7 +44,7 @@ router.delete("/:id", authenticateJWT("CHIEF"), teacherController.deleteTeacher)
  * /teacher/{academy_id}:
  *   get:
  *     summary: 학원의 모든 강사 조회
- *     description: CHIEF 권한을 가진 사용자가 특정 학원의 모든 강사 목록을 조회합니다.
+ *     description: CHIEF 권한을 가진 사용자가 특정 학원의 모든 강사 목록을 조회합니다. 강사의 학원 ID와 사용자 ID는 제외하고 반환됩니다.
  *     tags: [Teacher]
  *     security:
  *       - bearerAuth: []
@@ -67,27 +67,42 @@ router.delete("/:id", authenticateJWT("CHIEF"), teacherController.deleteTeacher)
  *                   type: string
  *                   description: "강사를 성공적으로 불러왔습니다."
  *                 data:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       email:
- *                         type: string
- *                         description: 강사의 이메일
- *                       phone_number:
- *                         type: string
- *                         description: 강사의 전화번호
- *                       lectures:
- *                         type: array
- *                         items:
- *                           type: object
- *                           properties:
- *                             lecture_id:
- *                               type: integer
- *                               description: 강의 ID
- *                             lecture_name:
- *                               type: string
- *                               description: 강의 이름
+ *                   type: object
+ *                   properties:
+ *                     academy_id:
+ *                       type: string
+ *                       description: 학원의 ID
+ *                     role:
+ *                       type: string
+ *                       description: 강사의 역할 (TEACHER)
+ *                     status:
+ *                       type: string
+ *                       description: 강사의 상태 (APPROVED)
+ *                     user:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           user_name:
+ *                             type: string
+ *                             description: 강사의 이름
+ *                           email:
+ *                             type: string
+ *                             description: 강사의 이메일
+ *                           phone_number:
+ *                             type: string
+ *                             description: 강사의 전화번호
+ *                           lectures:
+ *                             type: array
+ *                             items:
+ *                               type: object
+ *                               properties:
+ *                                 lecture_id:
+ *                                   type: integer
+ *                                   description: 강의 ID
+ *                                 lecture_name:
+ *                                   type: string
+ *                                   description: 강의 이름
  *       403:
  *         description: 학원에 대한 접근 권한이 없습니다.
  *       404:


### PR DESCRIPTION
## #️⃣연관된 이슈

#90 

## 📝작업 내용

기존 응답이

academy_id
role
status를 쓸데없이 강사마다 중복되어서 나타났었는데  -> 한번만 나오도록 수정

응답에 강사이름 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f5783b1f-4f4e-4668-a277-d8463ac11424)
![image](https://github.com/user-attachments/assets/5cf6a605-32b1-4eb9-a931-61b7371de658)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
