### PR TITLE
Fix/#132 exam examtype list

### DIFF
--- a/src/controllers/examTypeController.js
+++ b/src/controllers/examTypeController.js
@@ -59,6 +59,7 @@ exports.createExamType = asyncWrapper(async (req, res, next) => {
 
 exports.getExamType = asyncWrapper(async (req, res, next) => {
   const { academy_id } = req.params;
+  const { exam_type_name } = req.query;
 
   // 유효성 검사1: academy_id가 다른 학원이면 에러 처리
   if (academy_id !== req.user.academy_id) {
@@ -71,10 +72,14 @@ exports.getExamType = asyncWrapper(async (req, res, next) => {
     );
   }
 
+  // Prisma where 조건 동적 생성
+  const whereCondition = {
+    academy_id: academy_id,
+    ...(exam_type_name && { exam_type_name: { contains: exam_type_name } }), // exam_type_name이 제공되면 조건 추가
+  };
+
   const examTypeList = await prisma.ExamType.findMany({
-    where: {
-      academy_id: academy_id,
-    },
+    where: whereCondition,
   });
 
   // 유효성 검사2: examTypeList가 존재하지 않으면 에러 처리
@@ -87,6 +92,8 @@ exports.getExamType = asyncWrapper(async (req, res, next) => {
       )
     );
   }
+  
+  // 데이터 구조화
   const examTypes = examTypeList.map((x) => ({
     exam_type_name: x.exam_type_name,
     exam_type_id: x.exam_type_id,
@@ -101,6 +108,7 @@ exports.getExamType = asyncWrapper(async (req, res, next) => {
     },
   });
 });
+
 
 exports.deleteExamType = asyncWrapper(async (req, res, next) => {
   const { exam_type_id } = req.params;

--- a/src/controllers/lectureController.js
+++ b/src/controllers/lectureController.js
@@ -513,6 +513,7 @@ exports.createExam = asyncWrapper(async (req, res, next) => {
 
 exports.getExam = asyncWrapper(async (req, res, next) => {
   const { lecture_id } = req.params;
+  const { exam_type_id } = req.query;
 
   // 유효성 검사: lecture_id가 존재하지 않으면 에러 처리
   if (!lecture_id) {
@@ -526,10 +527,14 @@ exports.getExam = asyncWrapper(async (req, res, next) => {
   }
   const lecture_id_int = parseInt(lecture_id, 10);
 
+  // Prisma where 조건 동적 구성
+  const whereCondition = {
+    lecture_id: lecture_id_int,
+    ...(exam_type_id && { exam_type_id: parseInt(exam_type_id, 10) }), // exam_type_id가 존재할 경우 조건 추가
+  };
+
   const examList = await prisma.Exam.findMany({
-    where: {
-      lecture_id: lecture_id_int,
-    },
+    where: whereCondition,
   });
 
   // 유효성 검사: 존재하는 시험이 있는지 확인
@@ -547,11 +552,13 @@ exports.getExam = asyncWrapper(async (req, res, next) => {
     message: "시험을 성공적으로 불러왔습니다.",
     data: {
       lecture_id: lecture_id_int,
+      exam_type_id: exam_type_id,
       exams: examList,
       exam_cnt: examList.length,
     },
   });
 });
+
 
 exports.deleteExam = asyncWrapper(async (req, res, next) => {
   const { lecture_id, exam_id } = req.params;

--- a/src/routes/examTypeRouter.js
+++ b/src/routes/examTypeRouter.js
@@ -71,7 +71,7 @@ router.post(
  * /exam-type/academy/{academy_id}:
  *   get:
  *     summary: 학원의 시험 유형 조회
- *     description: CHIEF 또는 TEACHER 권한을 가진 사용자가 특정 학원의 시험 유형을 조회합니다. 요청한 사용자가 학원에 소속되지 않은 경우 접근이 제한됩니다.
+ *     description: CHIEF, TEACHER, STUDENT, PARENT 권한을 가진 사용자가 특정 학원의 시험 유형을 조회합니다. 요청한 사용자가 학원에 소속되지 않은 경우 접근이 제한됩니다. `exam_type_name` Query Parameter를 사용해 특정 이름을 포함하는 시험 유형을 필터링할 수 있습니다.
  *     tags: [ExamType]
  *     security:
  *       - bearerAuth: []
@@ -82,6 +82,12 @@ router.post(
  *         schema:
  *           type: string
  *         description: 조회할 학원의 ID
+ *       - in: query
+ *         name: exam_type_name
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: 특정 이름을 포함하는 시험 유형 필터링 (부분 일치)
  *     responses:
  *       200:
  *         description: 시험 유형 조회 성공
@@ -92,16 +98,19 @@ router.post(
  *               properties:
  *                 message:
  *                   type: string
- *                   description: "시험 유형을 성공적으로 불러왔습니다."
+ *                   description: 성공 메시지
+ *                   example: "시험 유형을 성공적으로 불러왔습니다."
  *                 data:
  *                   type: object
  *                   properties:
  *                     academy_id:
  *                       type: string
  *                       description: 학원의 ID
+ *                       example: "1234-5678-9012"
  *                     type_cnt:
  *                       type: integer
  *                       description: 개설된 시험 유형의 수
+ *                       example: 2
  *                     exam_types:
  *                       type: array
  *                       items:
@@ -110,18 +119,46 @@ router.post(
  *                           exam_type_name:
  *                             type: string
  *                             description: 시험 유형의 이름
+ *                             example: "중간고사"
  *                           exam_type_id:
  *                             type: integer
  *                             description: 시험 유형의 ID
- *       401:
- *         description: 인증 실패 또는 권한 부족
+ *                             example: 1
  *       403:
  *         description: 다른 학원에 접근할 수 없습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 접근 제한 메시지
+ *                   example: "다른 학원에는 접근할 수 없습니다."
  *       404:
  *         description: 개설된 시험 유형이 존재하지 않습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 데이터가 없을 때의 메시지
+ *                   example: "현재 개설된 시험 유형이 존재하지 않습니다."
  *       500:
  *         description: 서버 오류가 발생했습니다.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: 서버 에러 메시지
+ *                   example: "서버에서 오류가 발생했습니다."
  */
+
 // 시험 유형 조회
 router.get(
   "/academy/:academy_id",

--- a/src/routes/lectureRouter.js
+++ b/src/routes/lectureRouter.js
@@ -656,6 +656,7 @@ router.post(
  * /lecture/{lecture_id}/exam:
  *   get:
  *     summary: 강의에 대한 시험 목록 조회
+ *     description: 특정 강의의 시험 목록을 조회합니다. Optional Query Parameter로 `exam_type_id`를 제공하여 특정 시험 유형만 필터링할 수 있습니다.
  *     tags: [Lecture]
  *     security:
  *       - bearerAuth: []
@@ -666,6 +667,12 @@ router.post(
  *         schema:
  *           type: string
  *         description: 강의 ID
+ *       - in: query
+ *         name: exam_type_id
+ *         required: false
+ *         schema:
+ *           type: integer
+ *         description: 필터링할 시험 유형 ID
  *     responses:
  *       200:
  *         description: 성공적으로 시험을 불러옴
@@ -676,11 +683,13 @@ router.post(
  *               properties:
  *                 message:
  *                   type: string
+ *                   example: 시험을 성공적으로 불러왔습니다.
  *                 data:
  *                   type: object
  *                   properties:
  *                     lecture_id:
  *                       type: integer
+ *                       description: 강의 ID
  *                     exams:
  *                       type: array
  *                       items:
@@ -688,19 +697,45 @@ router.post(
  *                         properties:
  *                           exam_id:
  *                             type: integer
+ *                             description: 시험 ID
  *                           exam_name:
  *                             type: string
+ *                             description: 시험 이름
  *                           exam_date:
  *                             type: string
  *                             format: date
+ *                             description: 시험 날짜
+ *                           exam_type_id:
+ *                             type: integer
+ *                             description: 시험 유형 ID
+ *                           high_score:
+ *                             type: number
+ *                             description: 최고 점수
+ *                           low_score:
+ *                             type: number
+ *                             description: 최저 점수
+ *                           average_score:
+ *                             type: number
+ *                             description: 평균 점수
+ *                           total_score:
+ *                             type: number
+ *                             description: 총 점수
+ *                           created_at:
+ *                             type: string
+ *                             format: date-time
+ *                             description: 시험 생성 일시
+ *                           headcount:
+ *                             type: integer
+ *                             description: 시험 응시자 수
  *                     exam_cnt:
  *                       type: integer
+ *                       description: 조회된 시험의 총 개수
  *             example:
  *               message: "시험을 성공적으로 불러왔습니다."
  *               data:
  *                 lecture_id: 1001
  *                 exams:
- *                   - exam_id: 9,
+ *                   - exam_id: 9
  *                     lecture_id: 129
  *                     exam_name: "단원평가2"
  *                     high_score: 0
@@ -721,9 +756,9 @@ router.post(
  *               properties:
  *                 message:
  *                   type: string
- *             example:
- *               message: "현재 개설된 시험이 존재하지 않습니다."
+ *                   example: 현재 개설된 시험이 존재하지 않습니다.
  */
+
 // 시험 조회
 router.get(
   "/:lecture_id/exam",


### PR DESCRIPTION
## #️⃣연관된 이슈
#132
> ex) #이슈번호, #이슈번호
## 📝작업 내용
- 강의의 시험 목록 조회 API 수정
  - 원래는 lecture_id만 params로 받았는데, query로 exam_type_id도 받아서 조회함
  - exam_type_id가 있으면, 시험유형에 해당하는 시험 리턴. 
  - 없다면(null) 전체 시험 리턴.
- 학원 내의 시험유형 목록 조회 API 수정
  -  원래는 academy_id만 params로 받아 학원에 존재하는 전체 시험 유형을 리턴함. 
  - 여기서 시험유형의 이름을 query로 입력받아. 입력을 포함하는 이름을 갖는 시험유형 리턴하도록 수정. 
  - ex)?exam_type_name="고사" 로 입력 -> 만약 DB에 exam_type_id: exam_type_name 형식으로 {1:"중간고사"}, {2:"기말고사"} 이렇게 '고사를 포함하는 타입이 2개가 있으면, 이를 리턴.
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
- 존재하는 시험 목록
- ![image](https://github.com/user-attachments/assets/def10335-bcc5-4660-8964-1b88fb3f201b)
- 강의 내 시험 목록 조회 - 3: 퀴즈
- ![image](https://github.com/user-attachments/assets/c1abf1ce-9d92-44b1-831d-4728c7fc88f2)
- 강의 내 시험 목록 조회 - 전체
- ![image](https://github.com/user-attachments/assets/01538acd-68fc-4f82-b7c9-191b0412a9f2)
- 학원 내 시험 유형 목록 조회 - '고사'를 이름에 포함한 시험 유형들 -> '중간고사', '기말고사'
- ![image](https://github.com/user-attachments/assets/102f948a-0a9c-478e-b84a-6231a9823199)
- 학원 내 시험 유형 목록 조회 - 전체
- ![image](https://github.com/user-attachments/assets/c7e48322-950c-4463-929e-cf37661acda3)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
